### PR TITLE
[Feat] 시급 인상율 컴포넌트 프롭 추가

### DIFF
--- a/src/components/common/WageComparisonBadge.tsx
+++ b/src/components/common/WageComparisonBadge.tsx
@@ -1,21 +1,29 @@
 import Image from 'next/image';
 import classNames from 'classnames';
-import styles from './WageComparisonBadge.module.scss';
 import redArrow from '@/public/icons/wageArrowRed.svg';
 import whiteArrow from '@/public/icons/wageArrowWhite.svg';
+import styles from './WageComparisonBadge.module.scss';
 
 interface WageComparisonBadgeProps {
   change?: boolean;
+  hourlyPay: number;
+  originalHourlyPay: number;
 }
 
-function WageComparisonBadge({ change = false }: WageComparisonBadgeProps) {
+function WageComparisonBadge({
+  originalHourlyPay,
+  hourlyPay,
+  change = false,
+}: WageComparisonBadgeProps) {
+  const increaseRate = Math.ceil((hourlyPay / originalHourlyPay) * 100);
+
   return (
     <div
       className={classNames(styles.badge, {
         [styles.text]: change,
       })}
     >
-      기존 시급보다 50%
+      기존 시급보다 {increaseRate}%
       <Image
         className={classNames({ [styles.whiteArrow]: change })}
         width={20}


### PR DESCRIPTION
## 🚀 작업 내용

- 시급 인상 뱃지에 원래 시급과 (originalHourlyPay) 공고 시급(hourlyPay) 프롭을 추가하여 인상율 계산

## 📝 참고 사항

- ShopNoticeInfoBox가 뱃지에 전달하기 위한 프롭도 추가했고, 해당 컴포넌트 프롭은 객체로 묶었습니다. 

## 🖼️ 스크린샷
![image](https://github.com/sprint-part3-team10/tenten/assets/155133673/ba6fd1c7-8ec9-48e8-be16-0dfd18947220)

## 🚨 관련 이슈

- close #15 
- close #14 
