### PR TITLE
[Feat] Header의 검색바(SearchBar) 기능 구현 및 Input의 '원' 단위가 붙는 조건 변경

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,14 +1,40 @@
+'use client';
+
 import Image from 'next/image';
 import search from '@/public/icons/search.svg';
 import styles from './SearchBar.module.scss';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export default function SearchBar() {
+  const [searchShop, setSearchShop] = useState('');
+  const router = useRouter();
+
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchShop(event.target.value);
+  };
+
+  const handlePressKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      if (searchShop) {
+        router.push(`/search?keyword=${searchShop}`);
+      }
+    }
+    // ESC를 누를 경우, search 내용 지워짐
+    if (event.key === 'Escape') {
+      setSearchShop('');
+    }
+  };
+
   return (
     <div className={styles.container}>
       <Image src={search} width={20} height={20} alt='검색' />
       <input
         className={styles.searchInput}
         placeholder='가게 이름으로 찾아보세요.'
+        value={searchShop}
+        onChange={handleChangeInput}
+        onKeyDown={handlePressKey}
       />
     </div>
   );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -17,7 +17,7 @@ export default function SearchBar() {
   const handlePressKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       if (searchShop) {
-        router.push(`/search?keyword=${searchShop}`);
+        router.push(`/search?q=${searchShop}`);
       }
     }
     // ESC를 누를 경우, search 내용 지워짐

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -83,7 +83,7 @@ export default function Input({
             )}
           </button>
         )}
-        {(label === '시급*' || label === '금액') && (
+        {(label.includes('시급') || label.includes('금액')) && (
           <span className={styles.won}>원</span>
         )}
       </div>


### PR DESCRIPTION
## 🚀 작업 내용

- Header 내에 존재하는 SearchBar 기능 구현
    - 검색어 입력 후 'Enter' 키보드 입력 시, '/search?keyword=${검색어}' 링크로 이동
    - ESC를 입력할 경우, SearchBar 내 입력 내용이 지워진다.
- Input 컴포넌트에서 '원' 단위가 붙는 조건 변경
    - label에 '금액' 또는 '시급'이 포함되는 경우 단위가 붙도록 설정(includes 활용)

## 📝 참고 사항

- Search 검색 결과를 보여주는 페이지는 구현하지 않아 404 페이지가 보여지는 점 참고 바랍니다.

## 🖼️ 스크린샷

![SearchBar](https://github.com/sprint-part3-team10/tenten/assets/79882248/f32594af-6d57-4f5b-8a4d-d8e59c9ce290)


## 🚨 관련 이슈

- #5 
- #39 
