### PR TITLE
[Fixed] 공고 화면에서 logout 시 메인 화면으로 넘어가지 않는 문제 수정, 로그인 비밀번호 error 판단 case 수정

### DIFF
--- a/src/app/(auth)/signin/page.module.scss
+++ b/src/app/(auth)/signin/page.module.scss
@@ -4,7 +4,7 @@
 .container {
   @include container;
 
-  margin-top: 30rem;
+  margin-top: 25rem;
 }
 
 .form {

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -76,12 +76,7 @@ export default function SignIn() {
             inputType='password'
             placeholder='비밀번호'
             error={passwordError}
-            register={register('password', {
-              pattern: {
-                value: PASSWORD_REGEX,
-                message: '비밀번호는 8-16자, 문자 및 숫자를 포함해야 합니다',
-              },
-            })}
+            register={register('password')}
           />
           <Button buttonType='submit' text='로그인 하기' size='L' />
 

--- a/src/app/(auth)/signup/page.module.scss
+++ b/src/app/(auth)/signup/page.module.scss
@@ -3,12 +3,12 @@
 @mixin container {
   display: flex;
   flex-direction: column;
-  gap: 5rem;
+  gap: 4.5rem;
   align-items: center;
   justify-content: center;
   max-width: 35rem;
   margin: 0 auto;
-  margin-top: 25rem;
+  margin-top: 20rem;
 }
 
 @mixin form {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -3,12 +3,13 @@
 import Image from 'next/image';
 import search from '@/public/icons/search.svg';
 import styles from './SearchBar.module.scss';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function SearchBar() {
   const [searchShop, setSearchShop] = useState('');
   const router = useRouter();
+  const pathName = usePathname();
 
   const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchShop(event.target.value);
@@ -20,11 +21,17 @@ export default function SearchBar() {
         router.push(`/search?q=${searchShop}`);
       }
     }
-    // ESC를 누를 경우, search 내용 지워짐
+
     if (event.key === 'Escape') {
       setSearchShop('');
     }
   };
+
+  useEffect(() => {
+    if (!pathName.includes('search')) {
+      setSearchShop('');
+    }
+  }, [pathName]);
 
   return (
     <div className={styles.container}>

--- a/src/components/common/LogoutButton.tsx
+++ b/src/components/common/LogoutButton.tsx
@@ -17,8 +17,8 @@ export default function LogoutButton() {
 
   const handleLogout = async () => {
     await deleteCookie();
-    router.push('/');
-    window.location.reload();
+    router.replace('/');
+    router.refresh();
   };
 
   return (

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
           </Link>
         </div>
         <div className={styles.sns}>
-          <Link href='https://www.mail.google.com/'>
+          <Link href='https://www.google.com/'>
             <Image src={Envelope} alt='envelope Logo' width={25} height={25} />
           </Link>
           <Link href='https://www.facebook.com/'>


### PR DESCRIPTION
## 🚀 작업 내용

- 공고 화면에서 logout 시 메인 화면으로 넘어가지 않는 문제 수정
- 로그인에서 비밀번호 error(8-16자리 조건 등...) 케이스 판단 조건 삭제
- 검색 후, 검색 페이지(search)에서 벗어날 경우, 검색창 내에 있던 내용 초기화

## 📝 참고 사항

- window.location 방식 대신, replace 작업 후 router.refresh() 방식을 사용하였습니다.

## 🖼️ 스크린샷

- 로그아웃 문제 개선
![로그아웃](https://github.com/sprint-part3-team10/tenten/assets/79882248/d011b0e5-0eab-485f-874b-a3cf371b05bc)

- 로그인 error 케이스 수정
![로그인 개선](https://github.com/sprint-part3-team10/tenten/assets/79882248/ffd6a5d8-8db1-4363-8271-638b5d048848)

- 검색 이외의 페이지 이동 시 검색창 내 내용 초기화
![검색기능 개선](https://github.com/sprint-part3-team10/tenten/assets/79882248/9c885243-7377-472d-bd0d-84970eefa871)


## 🚨 관련 이슈

- #6 
- #68 
