### PR TITLE
[Design, Refactor] 헤더 버튼 hover 동작 추가, 검색바 반응형 동작 시 width 관련 수정, modal 버튼 크기 조정

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -82,8 +82,8 @@ export default function SignIn() {
 
           <div className={styles.movePage}>
             회원이 아니신가요?{' '}
-            <Link className={styles.signLink} href='/signup' scroll={false}>
-              회원가입하기
+            <Link className={styles.link} href='/signup' scroll={false}>
+              회원가입 하기
             </Link>
           </div>
         </form>

--- a/src/app/(auth)/signup/page.module.scss
+++ b/src/app/(auth)/signup/page.module.scss
@@ -28,6 +28,14 @@
   text-align: center;
 }
 
+@mixin link {
+  color: $pink-50;
+
+  &:hover {
+    color: $pink-20;
+  }
+}
+
 .wrapper {
   @include warpper;
 }
@@ -42,4 +50,8 @@
 
 .movePage {
   @include move;
+}
+
+.link {
+  @include link;
 }

--- a/src/components/SearchBar.module.scss
+++ b/src/components/SearchBar.module.scss
@@ -10,7 +10,7 @@
   border-radius: 1rem;
 
   @include media(tablet) {
-    width: 32rem;
+    width: 37rem;
   }
   @include media(mobile) {
     width: 100%;

--- a/src/components/SearchBar.module.scss
+++ b/src/components/SearchBar.module.scss
@@ -10,7 +10,7 @@
   border-radius: 1rem;
 
   @include media(tablet) {
-    width: 40rem;
+    width: 32rem;
   }
   @include media(mobile) {
     width: 100%;

--- a/src/components/common/Button.module.scss
+++ b/src/components/common/Button.module.scss
@@ -56,6 +56,7 @@
 @mixin small {
   @include text-12-l;
 
+  min-width: 8rem;
   padding: 0.8rem 1.2rem;
   line-height: 2rem;
 }

--- a/src/components/layout/Header.module.scss
+++ b/src/components/layout/Header.module.scss
@@ -53,6 +53,7 @@
   align-items: center;
   justify-content: center;
   margin-left: auto;
+  color: $black;
   white-space: nowrap;
 
   button {

--- a/src/components/layout/Header.module.scss
+++ b/src/components/layout/Header.module.scss
@@ -59,5 +59,9 @@
     @include text-16-b;
 
     background: $white;
+
+    &:hover {
+      color: $pink-50;
+    }
   }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 헤더 특정 부분 호버시 색 바꾸기
- 헤더 검색바 - tablet 사이즈로 줄일 경우, 버튼 사이의 여백을 둘 수 있도록 수정
    - 기존 tablet에서, 40rem → 32rem로 수정
- 모달 버튼 크기 수정
    - min-width: 8rem 설정

## 📝 참고 사항

- 

## 🖼️ 스크린샷

- 헤더 버튼 부분 hover 속성 추가
![image](https://github.com/sprint-part3-team10/tenten/assets/79882248/084298cf-b813-4239-a9e0-73737c21a191)

- 헤더 검색바
    - tablet 사이즈로 줄일 경우, 버튼 사이의 여백을 둘 수 있도록 수정
    - 수정 전
![Untitled](https://github.com/sprint-part3-team10/tenten/assets/79882248/6a43c560-3573-449f-8aa6-518596646caf)

   
    - 수정 후
![Untitled (1)](https://github.com/sprint-part3-team10/tenten/assets/79882248/4c09ade9-82cf-4837-b67b-5b6d52f502f4)


- 모달 버튼 크기 수정
    - min-width: 8rem 설정
    - 수정 전
![Untitled (2)](https://github.com/sprint-part3-team10/tenten/assets/79882248/ddebd262-1dda-400a-9899-4e59383da2ce)

    - 수정 후
![Untitled (3)](https://github.com/sprint-part3-team10/tenten/assets/79882248/a9e137e6-110d-4b34-812a-52d0db35f12a)



## 🚨 관련 이슈

- 
